### PR TITLE
Create database schema on application start if it does not exist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ aserto.directory.grpc.caCertPath=${user.home}/.config/topaz/certs/grpc-ca.crt
 logging.level.com.aserto=DEBUG
 server.port=3001
 
+# Create schema on startup
+spring.jpa.hibernate.ddl-auto=update
+
 
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-community-dialects</artifactId>
-            <version>6.1.6.Final</version>
+            <version>6.4.2.Final</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/aserto/store/DataSourceConfig.java
+++ b/src/main/java/com/aserto/store/DataSourceConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 import javax.sql.DataSource;
-import java.util.Properties;
 
 @Configuration
 public class DataSourceConfig {
@@ -15,13 +14,6 @@ public class DataSourceConfig {
         final DriverManagerDataSource dataSource = new DriverManagerDataSource();
         dataSource.setDriverClassName("org.sqlite.JDBC");
         dataSource.setUrl("jdbc:sqlite:mydb.db");
-
-        Properties properties = new Properties();
-        properties.setProperty("spring.jpa.database-platform", "org.hibernate.community.dialect.SQLiteDialect");
-        properties.setProperty("hibernate.hbm2ddl.auto", "update");
-        properties.setProperty("hibernate.show_sql", "true");
-
-        dataSource.setConnectionProperties(properties);
 
         return dataSource;
     }

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -30,3 +30,6 @@ aserto.directory.grpc.caCertPath=${user.home}/.config/topaz/certs/grpc-ca.crt
 # App configuration
 logging.level.com.aserto=DEBUG
 server.port=3001
+
+# Create the schema on startup
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
The mechanism we had to create/update the database schema on application start was not working. The schema was not created and the todo app was failing. 
This PR correctly sets spring to create/update the database schema on application start.